### PR TITLE
Don't immediately load ArcGIS metadata even if we already have it

### DIFF
--- a/Source/Core/TileProviderError.js
+++ b/Source/Core/TileProviderError.js
@@ -2,11 +2,13 @@
 define([
         './defaultValue',
         './defined',
-        './formatError'
+        './formatError',
+        './RuntimeError'
     ], function(
         defaultValue,
         defined,
-        formatError) {
+        formatError,
+        RuntimeError) {
     'use strict';
 
     /**
@@ -27,6 +29,8 @@ define([
      * @param {Error} [error] The error or exception that occurred, if any.
      */
     function TileProviderError(provider, message, x, y, level, timesRetried, error) {
+        this.name = 'TileProviderError';
+
         /**
          * The {@link ImageryProvider} or {@link TerrainProvider} that experienced the error.
          * @type {ImageryProvider|TerrainProvider}
@@ -148,6 +152,11 @@ define([
             previousError.timesRetried = -1;
         }
     };
+
+    if (defined(Object.create)) {
+        TileProviderError.prototype = Object.create(RuntimeError.prototype);
+        TileProviderError.prototype.constructor = TileProviderError;
+    }
 
     /**
      * A function that will be called to retry the operation.

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -111,7 +111,7 @@ define([
      * var esri = new Cesium.ArcGisMapServerImageryProvider({
      *     url : 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer'
      * });
-     * 
+     *
      * @see {@link http://resources.esri.com/help/9.3/arcgisserver/apis/rest/|ArcGIS Server REST API}
      * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
      */
@@ -243,7 +243,12 @@ define([
         }
 
         if (defined(options.mapServerData)) {
-            metadataSuccess(options.mapServerData);
+            // Even if we already have the map server data, we defer processing it in case there are
+            // errors.  Clients must have a chance to subscribe to the errorEvent before we raise it.
+            var mapServerData = options.mapServerData;
+            setTimeout(function() {
+                when(mapServerData, metadataSuccess, metadataFailure);
+            });
         } else if (this._useTiles) {
             requestMetadata();
         } else {


### PR DESCRIPTION
Because we need to give the caller time to subscribe to the error event (by returning from the constructor) before we raise it.

Fixes TerriaJS/terriajs#1741.
