### PR TITLE
Manually suffix loader names for webpack2

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -25,7 +25,7 @@ define([
 
     function canTransferArrayBuffer() {
         if (!defined(TaskProcessor._canTransferArrayBuffer)) {
-            var worker = require('worker!../Workers/transferTypedArrayTest')();
+            var worker = require('worker-loader!../Workers/transferTypedArrayTest')();
             worker.postMessage = defaultValue(worker.webkitPostMessage, worker.postMessage);
 
             var value = 99;
@@ -122,7 +122,7 @@ define([
 
 
     function createWorker(processor) {
-        var worker = require('worker?name=cesiumWorkers.js!../Workers/bootstrapper/cesiumWorkerBootstrapper')();
+        var worker = require('worker-loader?name=cesiumWorkers.js!../Workers/bootstrapper/cesiumWorkerBootstrapper')();
         worker.postMessage = defaultValue(worker.webkitPostMessage, worker.postMessage);
 
         var bootstrapMessage = {

--- a/Source/ThirdParty/zip.js
+++ b/Source/ThirdParty/zip.js
@@ -402,7 +402,7 @@ define([
 		}
 
 		if (obj.zip.useWebWorkers) {
-			worker = require('worker!./Workers/' + INFLATE_JS)();
+			worker = require('worker-loader!./Workers/' + INFLATE_JS)();
 			launchWorkerProcess(worker, reader, writer, offset, size, oninflateappend, onprogress, oninflateend, onreaderror, onwriteerror);
 		} else
 			launchProcess(new obj.zip.Inflater(), reader, writer, offset, size, oninflateappend, onprogress, oninflateend, onreaderror, onwriteerror);
@@ -427,7 +427,7 @@ define([
 		}
 
 		if (obj.zip.useWebWorkers) {
-			worker = require('worker!./Workers/' + DEFLATE_JS)();
+			worker = require('worker-loader!./Workers/' + DEFLATE_JS)();
 			worker.addEventListener(MESSAGE_EVENT, onmessage, false);
 			worker.postMessage({
 				init : true,


### PR DESCRIPTION
See https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed

Needed for nationalmap & terriajs `webpack2` branch.