### PR TITLE
Update ArcGisMapServerImageryProvider.js to add support for refreshing the token.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,8 @@ Change Log
 
 ### TerriaJS-only
 
-* Added support for refreshing expired tokens for `ArcGisMapServerImageryProvider` via callback registered with `options.requestNewToken` in constructor.
-
-### TerriaJS-only
-
 * Fixed a bug that could cause tiles to be missing from the globe surface, especially when starting with the camera zoomed close to the surface.
+* Added support for refreshing expired tokens for `ArcGisMapServerImageryProvider` via callback registered with `options.requestNewToken` in constructor.
 
 ### 1.33 - 2017-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ Change Log
 
 ### TerriaJS-only
 
+* Added support for refreshing expired tokens for `ArcGisMapServerImageryProvider` via callback registered with `options.requestNewToken` in constructor.
+
+### TerriaJS-only
+
 * Fixed a bug that could cause tiles to be missing from the globe surface, especially when starting with the camera zoomed close to the surface.
 
 ### 1.33 - 2017-05-01

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -711,8 +711,8 @@ define([
                     if (((requestErrorEvent.statusCode === 498) || (requestErrorEvent.statusCode === 499)) && (tokenRetries > 0)) {
                         tokenRetries--;
 
-                        // Note: The token may have already been updated between the request and now (when the responce is recieved),
-                        // but for now we don't detect and optomise for this case and send off a new token request regardless.
+                        // Note: The token may have already been updated between the request and now (when the response is received),
+                        // but for now we don't detect and optimize for this case and send off a new token request regardless.
                         return updateToken(that).then(() => {
                             // Rebuild the URL now that the token has been updated.
                             url = buildImageUrl(that, x, y, level);
@@ -765,8 +765,8 @@ define([
                     if (((json.error.code === 498) || (json.error.code === 499)) && defined(that._requestNewToken) && (tokenRetries > 0)) {
                         tokenRetries--;
 
-                        // Note: The token may have already been updated between the request and now (when the responce is recieved),
-                        // but for now we don't detect and optomise for this case and send off a new token request regardless.
+                        // Note: The token may have already been updated between the request and now (when the response is received),
+                        // but for now we don't detect and optimize for this case and send off a new token request regardless.
                         return updateToken(that).then(() => {
                             return loadJsonHandleError();
                         });

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -409,11 +409,7 @@ define([
                 return this._token;
             },
             set : function(token) {
-                delete this._token;
-
-                if (defined(token)) {
-                    this._token = token;
-                }
+                this._token = token;
             }
         },
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -59,6 +59,7 @@ define([
      * @param {Object} options Object with the following properties:
      * @param {String} options.url The URL of the ArcGIS MapServer service.
      * @param {String} [options.token] The ArcGIS token used to authenticate with the ArcGIS MapServer service.
+     * @param {Promise.<String>} [options.requestNewToken] A callback to retrieve new tokens if its detected that the current token has expired.
      * @param {TileDiscardPolicy} [options.tileDiscardPolicy] The policy that determines if a tile
      *        is invalid and should be discarded.  If this value is not specified, a default
      *        {@link DiscardMissingTileImagePolicy} is used for tiled map servers, and a
@@ -124,6 +125,7 @@ define([
 
         this._url = options.url;
         this._token = options.token;
+        this._requestNewToken = options.requestNewToken;
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._proxy = options.proxy;
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -703,8 +703,8 @@ define([
         if (!defined(this._requestNewToken)) {
             return ImageryProvider.loadImage(this, url);
         } else {
-            let that = this;
-            let tokenRetries = 1;
+            var that = this;
+            var tokenRetries = 1;
             function loadImageWithToken () {
                 return loadImageViaBlob(url).otherwise(function(requestErrorEvent) {
                     // If the token has expired or was not supplied the server sets the HTTP status code to 498/499 specifically to indicate these errors.
@@ -755,10 +755,10 @@ define([
             return undefined;
         }
 
-        let that = this;
-        let tokenRetries = 1;
+        var that = this;
+        var tokenRetries = 1;
         function loadJsonHandleError() {
-            let url = buildPickURL(that, x, y, level, longitude, latitude);
+            var url = buildPickURL(that, x, y, level, longitude, latitude);
             return loadJson(url).then(function(json) {
                 // In this case if the token fails the server returns with a HTTP status code of 200 and encodes the error as JSON.
                 if (defined(json.error) && defined(json.error.code)) {

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -572,36 +572,36 @@ define([
         }
         //>>includeEnd('debug');
 
+        var that = this;
+        var tokenRetries = 1;
+        function loadImageWithToken (url) {
+            var loadPromise = loadImageViaBlob(url);
+            if (!defined(loadPromise)) {
+                return loadPromise;
+            }
+
+            return loadPromise.otherwise(function(requestErrorEvent) {
+                // If the token has expired or was not supplied the server sets the HTTP status code to 498/499 specifically to indicate these errors.
+                if (((requestErrorEvent.statusCode === 498) || (requestErrorEvent.statusCode === 499)) && (tokenRetries > 0)) {
+                    tokenRetries--;
+
+                    // Note: The token may have already been updated between the request and now (when the response is received),
+                    // but for now we don't detect and optimize for this case and send off a new token request regardless.
+                    return updateToken(that).then(function () {
+                        // Rebuild the URL now that the token has been updated.
+                        url = buildImageUrl(that, x, y, level);
+                        return loadImageWithToken(url);
+                    });
+                }
+
+                throw requestErrorEvent;
+            });
+        }
+
         var url = buildImageUrl(this, x, y, level);
         if (!defined(this._requestNewToken)) {
             return ImageryProvider.loadImage(this, url);
         } else {
-            var that = this;
-            var tokenRetries = 1;
-            function loadImageWithToken (url) {
-                var loadPromise = loadImageViaBlob(url);
-                if (!defined(loadPromise)) {
-                    return loadPromise;
-                }
-
-                return loadPromise.otherwise(function(requestErrorEvent) {
-                    // If the token has expired or was not supplied the server sets the HTTP status code to 498/499 specifically to indicate these errors.
-                    if (((requestErrorEvent.statusCode === 498) || (requestErrorEvent.statusCode === 499)) && (tokenRetries > 0)) {
-                        tokenRetries--;
-
-                        // Note: The token may have already been updated between the request and now (when the response is received),
-                        // but for now we don't detect and optimize for this case and send off a new token request regardless.
-                        return updateToken(that).then(function () {
-                            // Rebuild the URL now that the token has been updated.
-                            url = buildImageUrl(that, x, y, level);
-                            return loadImageWithToken(url);
-                        });
-                    }
-
-                    throw requestErrorEvent;
-                });
-            }
-
             return throttleRequestByServer(url, loadImageWithToken);
         }
     };

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -377,7 +377,7 @@ define([
     function updateToken(imageryProvider) {
         if (!defined(imageryProvider._newTokenRequestInFlight) && defined(imageryProvider._requestNewToken)) {
             imageryProvider._newTokenRequestInFlight = imageryProvider._requestNewToken().then(function(newToken) {
-                delete imageryProvider._newTokenRequestInFlight;
+                imageryProvider._newTokenRequestInFlight = undefiend;
                 imageryProvider.token = newToken;
                 return newToken;
             });

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -651,15 +651,19 @@ define([
             return undefined;
         }
 
-        return loadJsonHandleTokenErrors(this);
+        var that = this;
+        return loadJsonHandleTokenErrors(this, function () {
+            var url = buildPickURL(that, x, y, level, longitude, latitude);
+            return loadJson(url)
+        }).then(function(json) {
+            return jsonToFeatures(json);
+        });
     };
 
-    function loadJsonHandleTokenErrors(item)
-    {
+    function loadJsonHandleTokenErrors(item, loadJson) {
         var tokenRetries = 1;
         function loadJsonHandleError() {
-            var url = buildPickURL(item, x, y, level, longitude, latitude);
-            return loadJson(url).then(function(json) {
+            return loadJson().then(function(json) {
                 // In this case if the token fails the server returns with a HTTP status code of 200 and encodes the error as JSON.
                 if (defined(json.error) && defined(json.error.code)) {
                     if (((json.error.code === 498) || (json.error.code === 499)) && defined(item._requestNewToken) && (tokenRetries > 0)) {
@@ -673,7 +677,7 @@ define([
                     }
                 }
 
-                return jsonToFeatures(json);
+                return json;
             });
         };
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -707,8 +707,8 @@ define([
             let tokenRetries = 1;
             function loadImageWithToken () {
                 return loadImageViaBlob(url).otherwise(function(requestErrorEvent) {
-                    // If the token has expired the server sets the HTTP status code to 498 specifically to indicate this error.
-                    if ((requestErrorEvent.statusCode === 498) && (tokenRetries > 0)) {
+                    // If the token has expired or was not supplied the server sets the HTTP status code to 498/499 specifically to indicate these errors.
+                    if (((requestErrorEvent.statusCode === 498) || (requestErrorEvent.statusCode === 499)) && (tokenRetries > 0)) {
                         tokenRetries--;
 
                         // Note: The token may have already been updated between the request and now (when the responce is recieved),
@@ -762,7 +762,7 @@ define([
             return loadJson(url).then(function(json) {
                 // In this case if the token fails the server returns with a HTTP status code of 200 and encodes the error as JSON.
                 if (defined(json.error) && defined(json.error.code)) {
-                    if ((json.error.code === 498) && defined(that._requestNewToken) && (tokenRetries > 0)) {
+                    if (((json.error.code === 498) || (json.error.code === 499)) && defined(that._requestNewToken) && (tokenRetries > 0)) {
                         tokenRetries--;
 
                         // Note: The token may have already been updated between the request and now (when the responce is recieved),

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -232,8 +232,7 @@ define([
         }
 
         function requestMetadata() {
-            let tokenRetries = 1;
-            function requestMetadataHandleTokenError() {
+            loadJsonHandleTokenErrors(that, function () {
                 var parameters = {
                     f: 'json'
                 };
@@ -245,25 +244,8 @@ define([
                 return loadJsonp(that._url, {
                     parameters : parameters,
                     proxy : that._proxy
-                }).then(function (json) {
-                    // In this case if the token fails the server returns with a HTTP status code of 200 and encodes the error as JSON.
-                    if (defined(json.error) && defined(json.error.code)) {
-                        if (((json.error.code === 498) || (json.error.code === 499)) && defined(that._requestNewToken) && (tokenRetries > 0)) {
-                            tokenRetries--;
-
-                            // Note: The token may have already been updated between the request and now (when the response is received),
-                            // but for now we don't detect and optimize for this case and send off a new token request regardless.
-                            return updateToken(that).then(() => {
-                                return requestMetadataHandleTokenError();
-                            });
-                        }
-                    }
-
-                    return json;
                 });
-            }
-
-            requestMetadataHandleTokenError().then(metadataSuccess).otherwise(metadataFailure);
+            }).then(metadataSuccess).otherwise(metadataFailure);
         }
 
         if (defined(options.mapServerData)) {

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -558,7 +558,7 @@ define([
         /**
          * Gets the comma-separated list of layer IDs to show.
          * @memberof ArcGisMapServerImageryProvider.prototype
-         * 
+         *
          * @type {String}
          */
         layers : {

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -591,7 +591,7 @@ define([
 
                         // Note: The token may have already been updated between the request and now (when the response is received),
                         // but for now we don't detect and optimize for this case and send off a new token request regardless.
-                        return updateToken(that).then(() => {
+                        return updateToken(that).then(function () {
                             // Rebuild the URL now that the token has been updated.
                             url = buildImageUrl(that, x, y, level);
                             return loadImageWithToken(url);
@@ -636,7 +636,7 @@ define([
         var that = this;
         return loadJsonHandleTokenErrors(this, function () {
             var url = buildPickURL(that, x, y, level, longitude, latitude);
-            return loadJson(url)
+            return loadJson(url);
         }).then(function(json) {
             return jsonToFeatures(json);
         });
@@ -653,7 +653,7 @@ define([
 
                         // Note: The token may have already been updated between the request and now (when the response is received),
                         // but for now we don't detect and optimize for this case and send off a new token request regardless.
-                        return updateToken(item).then(() => {
+                        return updateToken(item).then(function () {
                             return loadJsonHandleError();
                         });
                     }
@@ -661,7 +661,7 @@ define([
 
                 return json;
             });
-        };
+        }
 
         return loadJsonHandleError();
     }

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -63,7 +63,8 @@ define([
      * @param {Object} options Object with the following properties:
      * @param {String} options.url The URL of the ArcGIS MapServer service.
      * @param {String} [options.token] The ArcGIS token used to authenticate with the ArcGIS MapServer service.
-     * @param {Promise.<String>} [options.requestNewToken] A callback to retrieve new tokens if its detected that the current token has expired.
+     * @param {ArcGisMapServerImageryProvider~requestNewTokenCallback} [options.requestNewToken] A callback to retrieve new tokens if
+     *        its detected that the current token has expired or was not supplied.
      * @param {TileDiscardPolicy} [options.tileDiscardPolicy] The policy that determines if a tile
      *        is invalid and should be discarded.  If this value is not specified, a default
      *        {@link DiscardMissingTileImagePolicy} is used for tiled map servers, and a
@@ -802,3 +803,10 @@ define([
 
     return ArcGisMapServerImageryProvider;
 });
+
+/**
+ * A function that will make a request for a new token.
+ *
+ * @callback ArcGisMapServerImageryProvider~requestNewTokenCallback
+ * @return {Promise.<String>} A promise which will resolve to a new token.
+ */

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -240,11 +240,10 @@ define([
                 parameters.token = that._token;
             }
 
-            var metadata = loadJsonp(that._url, {
+            loadJsonp(that._url, {
                 parameters : parameters,
                 proxy : that._proxy
-            });
-            when(metadata, metadataSuccess, metadataFailure);
+            }).then(metadataSuccess).otherwise(metadataFailure);
         }
 
         if (defined(options.mapServerData)) {

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -651,19 +651,23 @@ define([
             return undefined;
         }
 
-        var that = this;
+        return loadJsonHandleTokenErrors(this);
+    };
+
+    function loadJsonHandleTokenErrors(item)
+    {
         var tokenRetries = 1;
         function loadJsonHandleError() {
-            var url = buildPickURL(that, x, y, level, longitude, latitude);
+            var url = buildPickURL(item, x, y, level, longitude, latitude);
             return loadJson(url).then(function(json) {
                 // In this case if the token fails the server returns with a HTTP status code of 200 and encodes the error as JSON.
                 if (defined(json.error) && defined(json.error.code)) {
-                    if (((json.error.code === 498) || (json.error.code === 499)) && defined(that._requestNewToken) && (tokenRetries > 0)) {
+                    if (((json.error.code === 498) || (json.error.code === 499)) && defined(item._requestNewToken) && (tokenRetries > 0)) {
                         tokenRetries--;
 
                         // Note: The token may have already been updated between the request and now (when the response is received),
                         // but for now we don't detect and optimize for this case and send off a new token request regardless.
-                        return updateToken(that).then(() => {
+                        return updateToken(item).then(() => {
                             return loadJsonHandleError();
                         });
                     }
@@ -674,7 +678,7 @@ define([
         };
 
         return loadJsonHandleError();
-    };
+    }
 
     function buildImageUrl(imageryProvider, x, y, level) {
         var url;

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -577,8 +577,8 @@ define([
         } else {
             var that = this;
             var tokenRetries = 1;
-            function loadImageWithToken () {
-                var loadPromise = throttleRequestByServer(url, loadImageViaBlob);
+            function loadImageWithToken (url) {
+                var loadPromise = loadImageViaBlob(url);
                 if (!defined(loadPromise)) {
                     return loadPromise;
                 }
@@ -593,7 +593,7 @@ define([
                         return updateToken(that).then(() => {
                             // Rebuild the URL now that the token has been updated.
                             url = buildImageUrl(that, x, y, level);
-                            return loadImageWithToken();
+                            return loadImageWithToken(url);
                         });
                     }
 
@@ -601,7 +601,7 @@ define([
                 });
             }
 
-            return loadImageWithToken();
+            return throttleRequestByServer(url, loadImageWithToken);
         }
     };
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -232,18 +232,22 @@ define([
         }
 
         function requestMetadata() {
-            var parameters = {
-                f: 'json'
-            };
+            function requestMetadataHandleTokenError() {
+                var parameters = {
+                    f: 'json'
+                };
 
-            if (defined(that._token)) {
-                parameters.token = that._token;
+                if (defined(that._token)) {
+                    parameters.token = that._token;
+                }
+
+                return loadJsonp(that._url, {
+                    parameters : parameters,
+                    proxy : that._proxy
+                });
             }
 
-            loadJsonp(that._url, {
-                parameters : parameters,
-                proxy : that._proxy
-            }).then(metadataSuccess).otherwise(metadataFailure);
+            requestMetadataHandleTokenError().then(metadataSuccess).otherwise(metadataFailure);
         }
 
         if (defined(options.mapServerData)) {

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -374,10 +374,11 @@ define([
         return result;
     }
 
-    function debounceRequestNewToken(imageryProvider) {
+    function updateToken(imageryProvider) {
         if (!defined(imageryProvider._newTokenRequestInFlight) && defined(imageryProvider._requestNewToken)) {
             imageryProvider._newTokenRequestInFlight = imageryProvider._requestNewToken().then(function(newToken) {
                 delete imageryProvider._newTokenRequestInFlight;
+                imageryProvider.token = newToken;
                 return newToken;
             });
         }
@@ -712,8 +713,7 @@ define([
 
                         // Note: The token may have already been updated between the request and now (when the responce is recieved),
                         // but for now we don't detect and optomise for this case and send off a new token request regardless.
-                        return debounceRequestNewToken(that).then(function(new_token) {
-                            that.token = new_token;
+                        return updateToken(that).then(() => {
                             // Rebuild the URL now that the token has been updated.
                             url = buildImageUrl(that, x, y, level);
                             return loadImageWithToken();
@@ -767,8 +767,7 @@ define([
 
                         // Note: The token may have already been updated between the request and now (when the responce is recieved),
                         // but for now we don't detect and optomise for this case and send off a new token request regardless.
-                        return debounceRequestNewToken(that).then(function(new_token) {
-                            that.token = new_token;
+                        return updateToken(that).then(() => {
                             return loadJsonHandleError();
                         });
                     }

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -17,6 +17,7 @@ define([
         '../Core/Math',
         '../Core/Rectangle',
         '../Core/RuntimeError',
+        '../Core/throttleRequestByServer',
         '../Core/TileProviderError',
         '../Core/WebMercatorProjection',
         '../Core/WebMercatorTilingScheme',
@@ -42,6 +43,7 @@ define([
         CesiumMath,
         Rectangle,
         RuntimeError,
+        throttleRequestByServer,
         TileProviderError,
         WebMercatorProjection,
         WebMercatorTilingScheme,
@@ -719,7 +721,12 @@ define([
             var that = this;
             var tokenRetries = 1;
             function loadImageWithToken () {
-                return loadImageViaBlob(url).otherwise(function(requestErrorEvent) {
+                var loadPromise = throttleRequestByServer(url, loadImageViaBlob);
+                if (!defined(loadPromise)) {
+                    return loadPromise;
+                }
+
+                return loadPromise.otherwise(function(requestErrorEvent) {
                     // If the token has expired or was not supplied the server sets the HTTP status code to 498/499 specifically to indicate these errors.
                     if (((requestErrorEvent.statusCode === 498) || (requestErrorEvent.statusCode === 499)) && (tokenRetries > 0)) {
                         tokenRetries--;

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -384,14 +384,20 @@ define([
         },
 
         /**
-         * Gets the ArcGIS token used to authenticate with the ArcGis MapServer service.
+         * The ArcGIS token used to authenticate with the ArcGis MapServer service.
          * @memberof ArcGisMapServerImageryProvider.prototype
          * @type {String}
-         * @readonly
          */
         token : {
             get : function() {
                 return this._token;
+            },
+            set : function(token) {
+                delete this._token;
+
+                if (defined(token)) {
+                    this._token = token;
+                }
             }
         },
 


### PR DESCRIPTION
I have left the following comment rather then addressing the issue because this is somewhat of an edge case (doesn't happen that often in practice) and it seems better to fire off multiple requests occasionally rather then complicate the code detecting and handling the code, but happy to resolve this issue if you feel this is better:
```
// Note: The token may have already been updated between the request and now (when the responce is recieved),
// but for now we don't detect and optomise for this case and send off a new token request regardless.
```

Here is some code that I mocked up to handle this properly:
```
+                let lastToken = that._token;
                 return loadImageViaBlob(url).otherwise(function(requestErrorEvent) {
                     // If the token has expired the server sets the HTTP status code to 498 specifically to indicate this error.
-                    if ((requestErrorEvent.statusCode === 498) && (tokenRetries > 0)) {
-                        tokenRetries--;
-
-                        // Note: The token may have already been updated between the request and now (when the responce is recieved),
-                        // but for now we don't detect and optomise for this case and send off a new token request regardless.
-                        return updateToken(that).then(() => {
-                            // Rebuild the URL now that the token has been updated.
-                            url = buildImageUrl(that, x, y, level);
-                            return loadImageWithToken();
-                        });
+                    if (requestErrorEvent.statusCode === 498) {
+
+                    // If the token has already been updated.
+                    if (lastToken !== that._token) {
+                        return loadJsonHandleError();
+                    } else {
+                        if (tokenRetries > 0) {
+                            tokenRetries--;
+                            return updateToken(that).then(() => {
+                                // Rebuild the URL now that the token has been updated.
+                                url = buildImageUrl(that, x, y, level);
+                                return loadImageWithToken();
+                            });
+                        }
                     }
+                }
```

The reason that I don't particularly like this is the intuition jump that you need from `lastToken = that._token` being a proxy for the value of the `url` component of `loadImageViaBlob(url)` changing which I think inhibits the maintainability of the code. Technically you could check if `url` has changed, but this is not particularly clean either.