### PR TITLE
Ansynchronous HTTP 202 support + user cancellation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fixed a bug that could cause tiles to be missing from the globe surface, especially when starting with the camera zoomed close to the surface.
 * Added support for refreshing expired tokens for `ArcGisMapServerImageryProvider` via callback registered with `options.requestNewToken` in constructor.
 * Added support for `parameters` to `ArcGisMapServerImageryProvider`.
+* Added Support for HTTP 202 headers, and cancelling them if the request object is marked as cancelled.
 
 ### 1.46 - 2018-06-01
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1260,7 +1260,11 @@ define([
             var timeout = options.timeout;
             var data = options.data;
             var deferred = when.defer();
+<<<<<<< Updated upstream
             var xhr = Resource._Implementations.loadWithXhr(resource.url, responseType, method, data, headers, deferred, overrideMimeType, timeout);
+=======
+            var xhr = Resource._Implementations.loadWithXhr(resource.url, responseType, method, data, headers, deferred, overrideMimeType, request);
+>>>>>>> Stashed changes
             if (defined(xhr) && defined(xhr.abort)) {
                 request.cancelFunction = function() {
                     xhr.abort();
@@ -1893,7 +1897,11 @@ define([
             }).end();
     }
 
+<<<<<<< Updated upstream
     Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType, timeout) {
+=======
+    Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType, request) {
+>>>>>>> Stashed changes
         var dataUriRegexResult = dataUriRegex.exec(url);
         if (dataUriRegexResult !== null) {
             deferred.resolve(decodeDataUri(dataUriRegexResult, responseType));
@@ -1969,6 +1977,31 @@ define([
             if (xhr.status === 204) {
                 // accept no content
                 deferred.resolve();
+            } else if (xhr.status === 202) {
+                //HTTP 202 is for a process that can take a while
+                //contains at minimum a location to get the 
+                //completed resource from
+                //and the permission to read the location
+                var newURL = xhr.getResponseHeader('Location');
+                if (newURL === undefined || newURL === null || newURL === "") {
+                    deferred.reject(new RuntimeError("HTTP 202 header with no Location.\n Contact the service owner directly about this misconfiguration.\n Using HTTP 202 responses requires 'Location' and 'Access-Control-Expose-Headers: Location' headers in the response"));
+                     return;
+                }
+                //if request still valid change url and call this function
+                if (!request.cancelled) {
+                    var newXHR;
+                    setTimeout(function(){
+                        if (!request.cancelled){
+                            newXHR = loadWithXhr.load.call(this,newURL, responseType, method, data, headers, deferred, overrideMimeType, timeout, request);
+                        } else {
+                            //user cancel request after waking from sleep
+                            return;
+                        }
+                    },10000);
+                    return newXHR
+                } else {
+                    return;//request has been cancelled by user before sleep
+                }
             } else if (defined(xhr.response) && (!defined(responseType) || (browserResponseType === responseType))) {
                 deferred.resolve(response);
             } else if ((responseType === 'json') && typeof response === 'string') {

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1260,14 +1260,11 @@ define([
             var timeout = options.timeout;
             var data = options.data;
             var deferred = when.defer();
-<<<<<<< Updated upstream
-            var xhr = Resource._Implementations.loadWithXhr(resource.url, responseType, method, data, headers, deferred, overrideMimeType, timeout);
-=======
-            var xhr = Resource._Implementations.loadWithXhr(resource.url, responseType, method, data, headers, deferred, overrideMimeType, request);
->>>>>>> Stashed changes
+            var xhr = Resource._Implementations.loadWithXhr(resource.url, responseType, method, data, headers, deferred, overrideMimeType, timeout, request);
             if (defined(xhr) && defined(xhr.abort)) {
                 request.cancelFunction = function() {
                     xhr.abort();
+                    request.cancel();
                 };
             }
             return deferred.promise;
@@ -1897,11 +1894,7 @@ define([
             }).end();
     }
 
-<<<<<<< Updated upstream
-    Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType, timeout) {
-=======
-    Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType, request) {
->>>>>>> Stashed changes
+    Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType, timeout, request) {
         var dataUriRegexResult = dataUriRegex.exec(url);
         if (dataUriRegexResult !== null) {
             deferred.resolve(decodeDataUri(dataUriRegexResult, responseType));
@@ -1992,7 +1985,7 @@ define([
                     var newXHR;
                     setTimeout(function(){
                         if (!request.cancelled){
-                            newXHR = loadWithXhr.load.call(this,newURL, responseType, method, data, headers, deferred, overrideMimeType, timeout, request);
+                            newXHR = Resource._Implementations.loadWithXhr.call(this,newURL, responseType, method, data, headers, deferred, overrideMimeType, timeout, request);
                         } else {
                             //user cancel request after waking from sleep
                             return;


### PR DESCRIPTION
Added Support for HTTP 202 headers, and cancelling them if the request object is marked as cancelled