### PR TITLE
Don't require that require.context exists.

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -138,7 +138,7 @@ import RuntimeError from './RuntimeError.js';
     var requireWasm;
 
     if (window.require) {
-        if (self.require.context) {
+        if (window.require.context) {
             requireWasmWrapper = window.require.context('../ThirdParty/Workers', false, /.*wasm_wrapper\.js$/);
             requireWasm = window.require.context('../ThirdParty', false, /\.wasm$/);
         } else {

--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -134,8 +134,22 @@ import RuntimeError from './RuntimeError.js';
         return worker;
     }
 
-    var requireWasmWrapper = require.context('../ThirdParty/Workers', false, /.*wasm_wrapper\.js$/);
-    var requireWasm = require.context('../ThirdParty', false, /\.wasm$/);
+    var requireWasmWrapper;
+    var requireWasm;
+
+    if (window.require) {
+        if (self.require.context) {
+            requireWasmWrapper = window.require.context('../ThirdParty/Workers', false, /.*wasm_wrapper\.js$/);
+            requireWasm = window.require.context('../ThirdParty', false, /\.wasm$/);
+        } else {
+            requireWasmWrapper = window.require;
+            requireWasm = window.require;
+        }
+    } else {
+        requireWasmWrapper = requireWasmWrapper = function() {
+            throw new DeveloperError('Cannot `require` in this environment.');
+        };
+    }
 
     function getWebAssemblyLoaderConfig(processor, wasmOptions) {
         var config = {


### PR DESCRIPTION
It doesn't e.g. in node.js.