### PR TITLE
Don't allow JulianDate.toIso8601 milliseconds to be formatted with exponential notation.

### DIFF
--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -665,7 +665,7 @@ import TimeStandard from './TimeStandard.js';
 
         if (!defined(precision) && millisecond !== 0) {
             //Forces milliseconds into a number with at least 3 digits to whatever the default toString() precision is.
-            millisecondStr = (millisecond * 0.01).toString().replace('.', '');
+            millisecondStr = sprintf('%f', millisecond * 0.01).replace('.', '');
             return sprintf('%04d-%02d-%02dT%02d:%02d:%02d.%sZ', year, month, day, hour, minute, second, millisecondStr);
         }
 


### PR DESCRIPTION
For example, if `millisecond` is 0.0000001, `toString` will format it as `1e-7`, which is not valid as part of an ISO8601 time.

Fixes TerriaJS/nsw-digital-twin#176
