### PR TITLE
Remove exports object from our fork and document decsion with an ADR

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,8 @@
 !Specs/**/
 !Tools/**/
 
+!terria-adr/**/
+
 !**/*.js
 !**/*.cjs
 !**/*.css

--- a/package.json
+++ b/package.json
@@ -35,10 +35,6 @@
   "main": "index.cjs",
   "module": "./Source/Cesium.js",
   "types": "./Source/Cesium.d.ts",
-  "exports": {
-    "require": "./index.cjs",
-    "import": "./Source/Cesium.js"
-  },
   "dependencies": {
     "dompurify": "^2.0.7"
   },

--- a/terria-adr/0000-record-architecture-decisions.md
+++ b/terria-adr/0000-record-architecture-decisions.md
@@ -1,0 +1,20 @@
+# 0. Record architecture decisions
+
+Date: 2020-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+We will have to write docs. 😱
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/terria-adr/0001-remove-exports-object.md
+++ b/terria-adr/0001-remove-exports-object.md
@@ -12,7 +12,7 @@ Cesium's `exports` object in `package.json` allows users of the "cesium" package
 However in TerriaJS we only import individual files from "terriajs-cesium". These imports would be broken by Cesium's current `exports`
 object when webpack or TypeScript respects this (implemented in webpack v5 beta version https://github.com/webpack/webpack/issues/9509).
 
-Also, and of more immediate concern, it also breaks our build process' method of finding the root directory of "terriajs-cesium" in Node v12.7.0+: 
+Also, and of more immediate concern, it also breaks our build process' method of finding the root directory of "terriajs-cesium" in Node v12.17.0+: 
 ```js
 require.resolve("terriajs-cesium/package.json")
 ```

--- a/terria-adr/0001-remove-exports-object.md
+++ b/terria-adr/0001-remove-exports-object.md
@@ -1,0 +1,25 @@
+# 1. remove exports object from package.json in terriajs' fork of cesium
+
+Date: 2020-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+Cesium's `exports` object in `package.json` allows users of the "cesium" package to use Cesium as an ESM or CommonJS package.
+However in TerriaJS we only import individual files from "terriajs-cesium". These imports would be broken by Cesium's current `exports`
+object when webpack or TypeScript respects this (implemented in webpack v5 beta version https://github.com/webpack/webpack/issues/9509).
+
+Also, and of more immediate concern, it also breaks our build process' method of finding the root directory of "terriajs-cesium" in Node v12.7.0+: 
+```js
+require.resolve("terriajs-cesium/package.json")
+```
+
+Discussion in https://github.com/nodejs/node/issues/33460 shows that there is no good replacement to requiring `package.json` for finding a 
+package's root directory.
+
+## Decision
+
+Remove the `exports` object in "terriajs-cesium", and don't merge any future changes made to `exports` in upstream "cesium" into our package.


### PR DESCRIPTION
Remove exports object as agreed on Slack. This allows builds of TerriaMap `master` to succeed on Node v14!
Also tested by applying on top of `terriajs-1.68.0` with TerriaMap & terriajs `next` branches, which also lead to a successful build on Node v14.
(Tested with Node v14.7.0.)

Also adds ADRs to terriajs-cesium. I've put them in the directory `terria-adr/` to ensure they don't clash with any upstream ADRs that may be added and also to make it clear on first glance that we do have Terria team ADRs in the repo.