### PR TITLE
fix wmts get feature info url

### DIFF
--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -677,7 +677,7 @@ import Uri from '../ThirdParty/Uri.js';
     ]);
 
     function buildGetFeatureInfoUrl(imageryProvider, infoFormat, col, row, level, i, j) {
-        var uri = new Uri(imageryProvider._url);
+        var uri = new Uri(imageryProvider.url);
         var queryOptions = queryToObject(defaultValue(uri.query, ''));
 
         queryOptions = combine(WebMapTileServiceImageryProvider.GetFeatureInfoDefaultParameters, queryOptions);


### PR DESCRIPTION
GetFeatureInfo url is not correct  for WebMapTileServiceImageryProvider. see https://github.com/TerriaJS/terriajs/pull/4720#issuecomment-695963658 for details