### PR TITLE
Remove exports from package.json as per ADR 1 (see terria-adr/)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,6 @@
   "main": "index.cjs",
   "module": "./Source/Cesium.js",
   "types": "./Source/Cesium.d.ts",
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "require": "./index.cjs",
-      "import": "./Source/Cesium.js"
-    }
-  },
   "dependencies": {
     "dompurify": "^2.0.7"
   },


### PR DESCRIPTION
`exports` should never be added to our fork of Cesium. See https://github.com/TerriaJS/cesium/blob/terriajs/terria-adr/0001-remove-exports-object.md.