### PR TITLE
feature info support for WMTS imagery provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Added `token`, `mapServerData`, and `parameters` properties to `ArcGisMapServerImageryProvider.ConstructorOptions`.
 - Added `Ion.defaultTokenMessage` to customize the credit message shown on the map when using default Ion token.
 - Added split terrain feature.
+- Added WMTS `GetFeatureInfo` support to `WebMapTileServiceImageryProvider`, including new constructor options and accompanying specs.
 
 ## 1.134 - 2025-10-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -432,3 +432,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Pamela Augustine](https://github.com/pamelaAugustine)
 - [宋时旺](https://github.com/BlockCnFuture)
 - [Marco Zhan](https://github.com/marcoYxz)
+- [Shubham Sharma](https://github.com/ShubhamSharmaFAO)


### PR DESCRIPTION
### Feature: WebMapTileService GetFeatureInfo support & specs

### Description
Adds WMTS GetFeatureInfo (feature picking) to `WebMapTileServiceImageryProvider`:
- New options: `enablePickFeatures` (default true), `getFeatureInfoFormats`, `getFeatureInfoUrl`, `getFeatureInfoParameters`.
- Implements `pickFeatures` via `UrlTemplateImageryProvider` + `GetFeatureInfoFormat`; supports both KVP and REST templating.
- Honors `dimensions` and time-dynamic values; supports JSON/XML/HTML with format fallback.
- Non‑breaking: default behavior enables picking; existing imagery fetching unchanged.
- Provides GetFeatureInfo for WMTS imagery layers.

### Issue number and link
- Discussion: `https://github.com/TerriaJS/terriajs/discussions/7603`

### Testing plan
- Lint/build/docs/types

```bash
npm run eslint
npm run build
npm run build-docs
npm run build-ts
```

- Targeted unit suite

```bash
npm run test -- --includeName WebMapTileServiceImageryProvider
```

- Verifies:
  - Disabled states: empty `getFeatureInfoFormats`, `enablePickFeatures=false`
  - Initialization for KVP and REST URLs
  - `getFeatureInfoUrl` override used for picking
  - Request construction (service/version/request/layer/style/tilematrixset/tilematrix/tilecol/tilerow/i/j/infoformat)
  - Dimensions in KVP (query) and REST (template) forms
  - Time-dynamic values in query and template (with URL-encoding)
  - `getFeatureInfoParameters` lowercased into query
  - JSON parsing to `ImageryLayerFeatureInfo[]` with name/position checks
  - XML (`fetchXML`) and HTML (`fetchText`) infoformats
  - Fallback to next format when the first request fails

### Author checklist
- [x] I have submitted a Contributor License Agreement
- [x] I have added my name to `CONTRIBUTORS.md`
- [x] I have updated `CHANGES.md` with a short summary of my change
- [x] I have added or updated unit tests to ensure consistent code coverage
- [x] I have updated the inline documentation, and included code examples where relevant
- [x] I have performed a self-review of my code