### PR TITLE
Update terrain splitter code in surface shader set.

### DIFF
--- a/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceShaderSet.js
@@ -8,15 +8,13 @@ import SceneMode from "./SceneMode.js";
 function GlobeSurfaceShader(
   numberOfDayTextures,
   flags,
-  flags2,
   material,
   shaderProgram,
   clippingShaderState,
-  clippingPolygonShaderState
+  clippingPolygonShaderState,
 ) {
   this.numberOfDayTextures = numberOfDayTextures;
   this.flags = flags;
-  this.flags2 = flags2;
   this.material = material;
   this.shaderProgram = shaderProgram;
   this.clippingShaderState = clippingShaderState;
@@ -168,40 +166,40 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
   // Flags beyond bit 31 use arithmetic to avoid silent wrap-around
   // (x << 32 === x << 0 in JavaScript).
   const flags =
-    sceneMode |
-    (applyBrightness << 2) |
-    (applyContrast << 3) |
-    (applyHue << 4) |
-    (applySaturation << 5) |
-    (applyGamma << 6) |
-    (applyAlpha << 7) |
-    (hasWaterMask << 8) |
-    (showReflectiveOcean << 9) |
-    (showOceanWaves << 10) |
-    (enableLighting << 11) |
-    (dynamicAtmosphereLighting << 12) |
-    (dynamicAtmosphereLightingFromSun << 13) |
-    (showGroundAtmosphere << 14) |
-    (perFragmentGroundAtmosphere << 15) |
-    (hasVertexNormals << 16) |
-    (useWebMercatorProjection << 17) |
-    (enableFog << 18) |
-    (quantization << 19) |
-    (applySplit << 20) |
-    (enableClippingPlanes << 21) |
-    (enableClippingPolygons << 22) |
-    (cartographicLimitRectangleFlag << 23) |
-    (imageryCutoutFlag << 24) |
-    (colorCorrect << 25) |
-    (highlightFillTile << 26) |
-    (colorToAlpha << 27) |
-    (hasGeodeticSurfaceNormals << 28) |
-    (hasExaggeration << 29) |
-    (showUndergroundColor << 30) |
-    (translucent << 31);
-
-  // More bit flags that don't fit in the first `flag`
-  const flags2 = applyDayNightAlpha | (splitTerrain << 2);
+    ((sceneMode |
+      (applyBrightness << 2) |
+      (applyContrast << 3) |
+      (applyHue << 4) |
+      (applySaturation << 5) |
+      (applyGamma << 6) |
+      (applyAlpha << 7) |
+      (hasWaterMask << 8) |
+      (showReflectiveOcean << 9) |
+      (showOceanWaves << 10) |
+      (enableLighting << 11) |
+      (dynamicAtmosphereLighting << 12) |
+      (dynamicAtmosphereLightingFromSun << 13) |
+      (showGroundAtmosphere << 14) |
+      (perFragmentGroundAtmosphere << 15) |
+      (hasVertexNormals << 16) |
+      (useWebMercatorProjection << 17) |
+      (enableFog << 18) |
+      (quantization << 19) |
+      (applySplit << 20) |
+      (enableClippingPlanes << 21) |
+      (enableClippingPolygons << 22) |
+      (cartographicLimitRectangleFlag << 23) |
+      (imageryCutoutFlag << 24) |
+      (colorCorrect << 25) |
+      (highlightFillTile << 26) |
+      (colorToAlpha << 27) |
+      (hasGeodeticSurfaceNormals << 28) |
+      (hasExaggeration << 29) |
+      (showUndergroundColor << 30) |
+      (translucent << 31)) >>>
+      0) +
+    (applyDayNightAlpha ? 0x100000000 : 0) +
+    (splitTerrain ? 0x1000000000 : 0);
 
   let currentClippingShaderState = 0;
   if (defined(clippingPlanes) && clippingPlanes.length > 0) {
@@ -222,7 +220,6 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
     defined(surfaceShader) &&
     surfaceShader.numberOfDayTextures === numberOfDayTextures &&
     surfaceShader.flags === flags &&
-    surfaceShader.flags2 === flags2 &&
     surfaceShader.material === this.material &&
     surfaceShader.clippingShaderState === currentClippingShaderState &&
     surfaceShader.clippingPolygonShaderState ===
@@ -237,12 +234,7 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
     shadersByFlags = this._shadersByTexturesFlags[numberOfDayTextures] = [];
   }
 
-  let shadersByFlags2 = shadersByFlags[flags];
-  if (!defined(shadersByFlags2)) {
-    shadersByFlags2 = shadersByFlags[flags2] = [];
-  }
-
-  surfaceShader = shadersByFlags2[flags2];
+  surfaceShader = shadersByFlags[flags];
   if (
     !defined(surfaceShader) ||
     surfaceShader.material !== this.material ||
@@ -257,7 +249,7 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
     // Need to go before GlobeFS
     if (currentClippingShaderState !== 0) {
       fs.sources.unshift(
-        getClippingFunction(clippingPlanes, frameState.context)
+        getClippingFunction(clippingPlanes, frameState.context),
       );
     }
 
@@ -271,7 +263,7 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
     fs.defines.push(
       `TEXTURE_UNITS ${numberOfDayTextures}`,
       cartographicLimitRectangleDefine,
-      imageryCutoutDefine
+      imageryCutoutDefine,
     );
 
     if (applyBrightness) {
@@ -369,10 +361,10 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
       }
 
       fs.defines.push(
-        `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`
+        `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`,
       );
       vs.defines.push(
-        `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`
+        `CLIPPING_POLYGON_REGIONS_LENGTH ${clippingPolygons.extentsCount}`,
       );
     }
 
@@ -461,17 +453,14 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
       attributeLocations: terrainEncoding.getAttributeLocations(),
     });
 
-    surfaceShader = new GlobeSurfaceShader(
+    surfaceShader = shadersByFlags[flags] = new GlobeSurfaceShader(
       numberOfDayTextures,
       flags,
-      flags2,
       this.material,
       shader,
       currentClippingShaderState,
-      currentClippingPolygonsShaderState
+      currentClippingPolygonsShaderState,
     );
-
-    shadersByFlags2[flags2] = surfaceShader;
   }
 
   surfaceTile.surfaceShader = surfaceShader;
@@ -479,7 +468,7 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
 };
 
 GlobeSurfaceShaderSet.prototype.destroy = function () {
-  let flags, flags2;
+  let flags;
   let shader;
 
   const shadersByTexturesFlags = this._shadersByTexturesFlags;
@@ -492,14 +481,9 @@ GlobeSurfaceShaderSet.prototype.destroy = function () {
 
       for (flags in shadersByFlags) {
         if (shadersByFlags.hasOwnProperty(flags)) {
-          const shadersByFlags2 = shadersByFlags[flags];
-          for (flags2 in shadersByFlags2) {
-            if (shadersByFlags2.hasOwnProperty(flags2)) {
-              shader = shadersByFlags2[flags2];
-              if (defined(shader)) {
-                shader.shaderProgram.destroy();
-              }
-            }
+          shader = shadersByFlags[flags];
+          if (defined(shader)) {
+            shader.shaderProgram.destroy();
           }
         }
       }


### PR DESCRIPTION
<!--
Thanks for the Pull Request!

Please review [Contribution Guide](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines).

-->

# Description

Fix terrain splitting to work with Cesium 1.139.1

<!-- Consider: Why is this change required? What problem does it solve? -->

<!-- Include screenshots if appropriate -->

## Issue number and link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Testing plan

- Add any dataset to workbench
- Open the compare tool
- From the workbench toggle the `Show terrain` option between Left, Both and Right
- The terrain should switch directions as expected

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

# Author checklist

- [ ] I have submitted a Contributor License Agreement
- [ ] I have added my name to `CONTRIBUTORS.md`
- [ ] I have updated `CHANGES.md` with a short summary of my change
- [ ] I have added or updated unit tests to ensure consistent code coverage
- [ ] I have updated the inline documentation, and included code examples where relevant
- [ ] I have performed a self-review of my code
